### PR TITLE
Fixes/vite

### DIFF
--- a/.env.example.dev
+++ b/.env.example.dev
@@ -25,6 +25,7 @@ CRAFT_DISALLOW_ROBOTS=true
 
 # Vite Settings
 VITE_MANIFEST=@webroot/dist/.vite/manifest.json
-VITE_DEV_URL=${DDEV_PRIMARY_URL}:5173 # use for devServerPublic and devServerInternal
-VITE_BUILD_URL=${DDEV_PRIMARY_URL}/dist/ # use for serverPublic
 VITE_ERROR_ENTRY=src/entrypoint.js
+VITE_DEV_SERVER_PUBLIC=${DDEV_PRIMARY_URL}:5173
+VITE_SERVER_PUBLIC=${PRIMARY_SITE_URL}/dist/
+VITE_DEV_SERVER_INTERNAL=http://localhost:5173

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,11 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
-  "[html,php]": {
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[php]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "craftcms/cms": "5.6.16",
+    "craftcms/cms": "5.6.17",
     "nystudio107/craft-imageoptimize": "^5.0.7",
     "nystudio107/craft-seomatic": "5.1.12",
     "nystudio107/craft-templatecomments": "^5.0.4",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "heyblackmagic/foundation",
   "type": "project",
-  "version": "3.2",
+  "version": "3.2.1",
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea96d38471216d4bcd8aa3db324d8568",
+    "content-hash": "7aae2e27c7b396455c42310403f7d7d1",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -7059,11 +7059,11 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1bfc927a86d2a64b0d3b66e8eddad585",
+    "content-hash": "ea96d38471216d4bcd8aa3db324d8568",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -254,11 +254,11 @@
         },
         {
             "name": "craftcms/cms",
-            "version": "5.6.16",
+            "version": "5.6.17",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/craftcms/cms/zipball/d4e5d887fb2cdd94e91067300393518dc0a8f03e",
-                "reference": "d4e5d887fb2cdd94e91067300393518dc0a8f03e",
+                "url": "https://api.github.com/repos/craftcms/cms/zipball/19ce0bab651ab52c7b394f5f4a2ed0621ba90bd7",
+                "reference": "19ce0bab651ab52c7b394f5f4a2ed0621ba90bd7",
                 "shasum": ""
             },
             "require": {
@@ -358,7 +358,7 @@
                 "docs": "https://craftcms.com/docs/5.x/",
                 "rss": "https://github.com/craftcms/cms/releases.atom"
             },
-            "time": "2025-04-08T16:22:50+00:00"
+            "time": "2025-04-10T22:42:18+00:00"
         },
         {
             "name": "craftcms/plugin-installer",
@@ -2599,11 +2599,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.1",
+            "version": "5.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "92dde6a5919e34835c506ac8c523ef095a95ed62"
+            },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
-                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/92dde6a5919e34835c506ac8c523ef095a95ed62",
+                "reference": "92dde6a5919e34835c506ac8c523ef095a95ed62",
                 "shasum": ""
             },
             "require": {
@@ -2614,6 +2619,15 @@
                 "phpdocumentor/type-resolver": "^1.7",
                 "phpstan/phpdoc-parser": "^1.7|^2.0",
                 "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26"
             },
             "type": "library",
             "extra": {
@@ -2626,6 +2640,7 @@
                     "phpDocumentor\\Reflection\\": "src"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -2640,7 +2655,11 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2024-12-07T09:39:29+00:00"
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.2"
+            },
+            "time": "2025-04-13T19:20:35+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -6605,16 +6624,28 @@
         },
         {
             "name": "nette/php-generator",
-            "version": "v4.1.6",
+            "version": "v4.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/php-generator.git",
+                "reference": "42806049a7774a2bd316c958f5dcf01c6b5c56fa"
+            },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/php-generator/zipball/c90961e782ae86e517fe5ed732eb2b512945565b",
-                "reference": "c90961e782ae86e517fe5ed732eb2b512945565b",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/42806049a7774a2bd316c958f5dcf01c6b5c56fa",
+                "reference": "42806049a7774a2bd316c958f5dcf01c6b5c56fa",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^3.2.9 || ^4.0",
                 "php": "8.0 - 8.4"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "dev-master",
+                "nette/tester": "^2.4",
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "phpstan/phpstan": "^1.0",
+                "tracy/tracy": "^2.8"
             },
             "suggest": {
                 "nikic/php-parser": "to use ClassType::from(withBodies: true) & ClassType::fromCode()"
@@ -6630,6 +6661,7 @@
                     "src/"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause",
                 "GPL-2.0-only",
@@ -6645,7 +6677,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 8.3 features.",
+            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 8.4 features.",
             "homepage": "https://nette.org",
             "keywords": [
                 "code",
@@ -6653,15 +6685,24 @@
                 "php",
                 "scaffolding"
             ],
-            "time": "2024-09-10T09:31:55+00:00"
+            "support": {
+                "issues": "https://github.com/nette/php-generator/issues",
+                "source": "https://github.com/nette/php-generator/tree/v4.1.8"
+            },
+            "time": "2025-03-31T00:29:29+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.5",
+            "version": "v4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "ce708655043c7050eb050df361c5e313cf708309"
+            },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
-                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
+                "url": "https://api.github.com/repos/nette/utils/zipball/ce708655043c7050eb050df361c5e313cf708309",
+                "reference": "ce708655043c7050eb050df361c5e313cf708309",
                 "shasum": ""
             },
             "require": {
@@ -6670,6 +6711,12 @@
             "conflict": {
                 "nette/finder": "<3",
                 "nette/schema": "<1.2.2"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "dev-master",
+                "nette/tester": "^2.5",
+                "phpstan/phpstan": "^1.0",
+                "tracy/tracy": "^2.9"
             },
             "suggest": {
                 "ext-gd": "to use Image",
@@ -6690,6 +6737,7 @@
                     "src/"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause",
                 "GPL-2.0-only",
@@ -6723,7 +6771,11 @@
                 "utility",
                 "validation"
             ],
-            "time": "2024-08-07T15:39:19+00:00"
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v4.0.6"
+            },
+            "time": "2025-03-30T21:06:30+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -6769,41 +6821,48 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.11.22",
+            "version": "v0.12.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bobthecow/psysh.git",
+                "reference": "85057ceedee50c49d4f6ecaff73ee96adb3b3625"
+            },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/128fa1b608be651999ed9789c95e6e2a31b5802b",
-                "reference": "128fa1b608be651999ed9789c95e6e2a31b5802b",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/85057ceedee50c49d4f6ecaff73ee96adb3b3625",
+                "reference": "85057ceedee50c49d4f6ecaff73ee96adb3b3625",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "nikic/php-parser": "^4.0 || ^3.1",
-                "php": "^8.0 || ^7.0.8",
-                "symfony/console": "^6.0 || ^5.0 || ^4.0 || ^3.4",
-                "symfony/var-dumper": "^6.0 || ^5.0 || ^4.0 || ^3.4"
+                "nikic/php-parser": "^5.0 || ^4.0",
+                "php": "^8.0 || ^7.4",
+                "symfony/console": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4",
+                "symfony/var-dumper": "^7.0 || ^6.0 || ^5.0 || ^4.0 || ^3.4"
             },
             "conflict": {
                 "symfony/console": "4.4.37 || 5.3.14 || 5.3.15 || 5.4.3 || 5.4.4 || 6.0.3 || 6.0.4"
             },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2"
+            },
             "suggest": {
                 "ext-pcntl": "Enabling the PCNTL extension makes PsySH a lot happier :)",
                 "ext-pdo-sqlite": "The doc command requires SQLite to work.",
-                "ext-posix": "If you have PCNTL, you'll want the POSIX extension as well.",
-                "ext-readline": "Enables support for arrow-key history navigation, and showing and manipulating command history."
+                "ext-posix": "If you have PCNTL, you'll want the POSIX extension as well."
             },
             "bin": [
                 "bin/psysh"
             ],
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-0.11": "0.11.x-dev"
-                },
                 "bamarni-bin": {
                     "bin-links": false,
                     "forward-command": false
+                },
+                "branch-alias": {
+                    "dev-main": "0.12.x-dev"
                 }
             },
             "autoload": {
@@ -6814,6 +6873,7 @@
                     "Psy\\": "src/"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -6832,51 +6892,54 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2023-10-14T21:56:36+00:00"
+            "support": {
+                "issues": "https://github.com/bobthecow/psysh/issues",
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.8"
+            },
+            "time": "2025-03-16T03:05:19+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.20",
+            "version": "v7.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "2e4af9c952617cc3f9559ff706aee420a8464c36"
+                "reference": "e51498ea18570c062e7df29d05a7003585b19b88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/2e4af9c952617cc3f9559ff706aee420a8464c36",
-                "reference": "2e4af9c952617cc3f9559ff706aee420a8464c36",
+                "url": "https://api.github.com/repos/symfony/console/zipball/e51498ea18570c062e7df29d05a7003585b19b88",
+                "reference": "e51498ea18570c062e7df29d05a7003585b19b88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.2",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0|^7.0"
+                "symfony/string": "^6.4|^7.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
                 "symfony/http-foundation": "^6.4|^7.0",
                 "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -6910,7 +6973,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.20"
+                "source": "https://github.com/symfony/console/tree/v7.2.5"
             },
             "funding": [
                 {
@@ -6926,19 +6989,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-03T17:16:38+00:00"
+            "time": "2025-03-12T08:11:12+00:00"
         },
         {
             "name": "yiisoft/yii2-shell",
-            "version": "2.0.5",
+            "version": "2.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/yiisoft/yii2-shell.git",
+                "reference": "c0aef8874eb6e9e6a56cf2972e422457008f9e18"
+            },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii2-shell/zipball/358d4651ce1f54db0f1add026c202ac2e47db06b",
-                "reference": "358d4651ce1f54db0f1add026c202ac2e47db06b",
+                "url": "https://api.github.com/repos/yiisoft/yii2-shell/zipball/c0aef8874eb6e9e6a56cf2972e422457008f9e18",
+                "reference": "c0aef8874eb6e9e6a56cf2972e422457008f9e18",
                 "shasum": ""
             },
             "require": {
-                "psy/psysh": "~0.9.3|~0.10.3|^0.11.0",
+                "psy/psysh": "~0.9.3|~0.10.3|^0.11.0|^0.12.0",
                 "symfony/var-dumper": "~2.7|~3.0|~4.0|~5.0",
                 "yiisoft/yii2": "~2.0.0"
             },
@@ -6954,6 +7022,7 @@
                     "yii\\shell\\": ""
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -6972,16 +7041,29 @@
                 "shell",
                 "yii2"
             ],
-            "time": "2022-09-04T10:37:52+00:00"
+            "support": {
+                "forum": "https://www.yiiframework.com/forum/",
+                "irc": "ircs://irc.libera.chat:6697/yii",
+                "issues": "https://github.com/yiisoft/yii2-shell/issues",
+                "source": "https://github.com/yiisoft/yii2-shell",
+                "wiki": "https://www.yiiframework.com/wiki/"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/yiisoft",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-02-13T21:05:12+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.2"
     },

--- a/config/general.php
+++ b/config/general.php
@@ -26,10 +26,6 @@ return GeneralConfig::create()
         '@web' => App::env('PRIMARY_SITE_URL'),
         '@siteUrl' => App::env('PRIMARY_SITE_URL'),
         '@url' => App::env('PRIMARY_SITE_URL'),
-        '@viteManifest' => App::env('VITE_MANIFEST'),
-        '@viteDevUrl' => App::env('VITE_DEV_URL'),
-        '@viteBuildUrl' => App::env('VITE_BUILD_URL'),
-        '@viteErrorEntry' => App::env('VITE_ERROR_ENTRY'),
         '@assets' => "@webroot/assets",
     ])
 ;

--- a/config/general.php
+++ b/config/general.php
@@ -22,10 +22,9 @@ return GeneralConfig::create()
     ->preventUserEnumeration()
     // Set the @webroot alias so the clear-caches command knows where to find CP resources
     ->aliases([
-        '@webroot' => dirname(__DIR__) . '/public_html',
-        '@web' => App::env('PRIMARY_SITE_URL'),
-        '@siteUrl' => App::env('PRIMARY_SITE_URL'),
-        '@url' => App::env('PRIMARY_SITE_URL'),
-        '@assets' => "@webroot/assets",
-    ])
-;
+        "@webroot" => dirname(__DIR__) . "/public_html",
+        "@web" => App::env("PRIMARY_SITE_URL"),
+        "@siteUrl" => App::env("PRIMARY_SITE_URL"),
+        "@url" => App::env("PRIMARY_SITE_URL"),
+        "@assets" => "@webroot/assets",
+    ]);

--- a/config/vite.php
+++ b/config/vite.php
@@ -25,72 +25,72 @@ use craft\helpers\App;
  */
 
 return [
-
     /**
      * @var bool Should the dev server be used?
      */
-    'useDevServer' => App::env('ENVIRONMENT') === 'dev' || App::env('CRAFT_ENVIRONMENT') === 'dev',
+    "useDevServer" => App::env("ENVIRONMENT") === "dev" || App::env("CRAFT_ENVIRONMENT") === "dev",
 
     /**
      * @var string File system path (or URL) to the Vite-built manifest.json
      */
-    'manifestPath' => App::env('VITE_MANIFEST'),
+    "manifestPath" => App::env("VITE_MANIFEST"),
 
     /**
      * @var string The public URL to the dev server (what appears in `<script src="">` tags
      */
-    'devServerPublic' => App::env('VITE_DEV_SERVER_PUBLIC'),
+    "devServerPublic" => App::env("VITE_DEV_SERVER_PUBLIC"),
 
     /**
      * @var string The public URL to use when not using the dev server
      */
-    'serverPublic' => App::env('VITE_SERVER_PUBLIC'),
+    "serverPublic" => App::env("VITE_SERVER_PUBLIC"),
 
     /**
      * @var string|array The JavaScript entry from the manifest.json to inject on Twig error pages
      *              This can be a string or an array of strings
      */
-    'errorEntry' => App::env('VITE_ERROR_ENTRY'),
+    "errorEntry" => App::env("VITE_ERROR_ENTRY"),
 
     /**
      * @var string String to be appended to the cache key
      */
-    'cacheKeySuffix' => '',
+    "cacheKeySuffix" => "",
 
     /**
      * @var string The internal URL to the dev server, when accessed from the environment in which PHP is executing
      *              This can be the same as `$devServerPublic`, but may be different in containerized or VM setups.
      *              ONLY used if $checkDevServer = true
      */
-    'devServerInternal' => App::env('VITE_DEV_SERVER_INTERNAL'),
+    "devServerInternal" => App::env("VITE_DEV_SERVER_INTERNAL"),
 
     /**
      * @var bool Should we check for the presence of the dev server by pinging $devServerInternal to make sure it's running?
      */
-    'checkDevServer' => App::env('ENVIRONMENT') === 'dev' || App::env('CRAFT_ENVIRONMENT') === 'dev',
+    "checkDevServer" =>
+        App::env("ENVIRONMENT") === "dev" || App::env("CRAFT_ENVIRONMENT") === "dev",
 
     /**
      * @var bool Whether the react-refresh-shim should be included
      */
-    'includeReactRefreshShim' => false,
+    "includeReactRefreshShim" => false,
 
     /**
      * @var bool Whether the modulepreload-polyfill shim should be included
      */
-    'includeModulePreloadShim' => true,
+    "includeModulePreloadShim" => true,
 
     /**
      * @var string File system path (or URL) to where the Critical CSS files are stored
      */
-    'criticalPath' => '',
+    "criticalPath" => "",
 
     /**
      * @var string the suffix added to the name of the currently rendering template for the critical css file name
      */
-    'criticalSuffix' => '',
+    "criticalSuffix" => "",
 
     /**
      * @var bool Whether an onload handler should be added to <script> tags to fire a custom event when the script has loaded
      */
-    'includeScriptOnloadHandler' => true,
+    "includeScriptOnloadHandler" => true,
 ];

--- a/config/vite.php
+++ b/config/vite.php
@@ -34,23 +34,23 @@ return [
     /**
      * @var string File system path (or URL) to the Vite-built manifest.json
      */
-    'manifestPath' => '@viteManifest',
+    'manifestPath' => App::env('VITE_MANIFEST'),
 
     /**
      * @var string The public URL to the dev server (what appears in `<script src="">` tags
      */
-    'devServerPublic' => '@viteDevUrl',
+    'devServerPublic' => App::env('VITE_DEV_SERVER_PUBLIC'),
 
     /**
      * @var string The public URL to use when not using the dev server
      */
-    'serverPublic' => '@viteBuildUrl',
+    'serverPublic' => App::env('VITE_SERVER_PUBLIC'),
 
     /**
      * @var string|array The JavaScript entry from the manifest.json to inject on Twig error pages
      *              This can be a string or an array of strings
      */
-    'errorEntry' => '@viteErrorEntry',
+    'errorEntry' => App::env('VITE_ERROR_ENTRY'),
 
     /**
      * @var string String to be appended to the cache key
@@ -62,7 +62,7 @@ return [
      *              This can be the same as `$devServerPublic`, but may be different in containerized or VM setups.
      *              ONLY used if $checkDevServer = true
      */
-    'devServerInternal' => '@viteDevUrl',
+    'devServerInternal' => App::env('VITE_DEV_SERVER_INTERNAL'),
 
     /**
      * @var bool Should we check for the presence of the dev server by pinging $devServerInternal to make sure it's running?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundation",
-  "version": "3.1.1",
+  "version": "3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundation",
-      "version": "3.1.1",
+      "version": "3.2",
       "devDependencies": {
         "@prettier/plugin-php": "^0.22.4",
         "@tailwindcss/vite": "^4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundation",
-  "version": "3.2",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundation",
-      "version": "3.2",
+      "version": "3.2.1",
       "devDependencies": {
         "@prettier/plugin-php": "^0.22.4",
         "@tailwindcss/vite": "^4.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foundation",
-  "version": "3.2",
+  "version": "3.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -31,6 +31,7 @@ const config = {
       options: {
         phpVersion: "8.2",
         tabWidth: 4,
+        singleQuote: false,
       },
     },
     {


### PR DESCRIPTION
This pull request includes several updates and improvements across multiple configuration files. The main changes involve updates to environment variables, formatting settings, and version increments for dependencies.

### Environment Variables and Configuration:
* [`.env.example.dev`](diffhunk://#diff-59fe9fa32449239d2a51c339d5186ba9348a692e056cd495361ea5fb3b0c8316L28-R31): Updated Vite settings to include `VITE_DEV_SERVER_PUBLIC`, `VITE_SERVER_PUBLIC`, and `VITE_DEV_SERVER_INTERNAL` variables.
* [`config/general.php`](diffhunk://#diff-f37419bd95f400929d4e5ee19ddd43a0925e076b9038712a57154ae1d9d48891L25-R30): Simplified alias definitions by removing redundant Vite-related aliases.
* [`config/vite.php`](diffhunk://#diff-de419ff8cc994af24423b687c7609783a412f35d160eb47ed22462770ba1914dL28-R95): Updated to use environment variables directly for Vite server settings.

### Formatting and Editor Settings:
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L6-R10): Split formatter settings for `html` and `php` to ensure proper formatting for each language.
* [`prettier.config.js`](diffhunk://#diff-e42472dd65561fe56344281078077fb924cddca92821eadfbc2318cca3f89c9aR34): Added `singleQuote: false` option for PHP formatting.

### Version Increments:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L4-R8): Incremented project version to `3.2.1` and updated `craftcms/cms` dependency to `5.6.17`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Incremented project version to `3.2.1`.